### PR TITLE
fix: add initState method to start animating text after widget is built

### DIFF
--- a/lib/text_marquee.dart
+++ b/lib/text_marquee.dart
@@ -59,6 +59,14 @@ class _TextMarqueeState extends State<TextMarquee> {
   bool _isScrolling = false;
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _startAnimating();
+    });
+  }
+
+  @override
   void didUpdateWidget(TextMarquee oldWidget) {
     // The commands inside this callback are executed after the build function.
     WidgetsBinding.instance.addPostFrameCallback((_) {


### PR DESCRIPTION
Hi!

I encountered an issue while using this package where the text animation only started after performing a hot reload. To fix this, I added a call to `_startAnimating` in the `initState` method, which resolves the problem and ensures the text animates right after the widget is built. 

Let me know what you think! :)