### PR TITLE
fix: prevent ScrollController error when navigating away from TextMarquee

### DIFF
--- a/lib/text_marquee.dart
+++ b/lib/text_marquee.dart
@@ -80,6 +80,9 @@ class _TextMarqueeState extends State<TextMarquee> {
     // Apply delay to start scrolling.
     await Future.delayed(widget.delay);
 
+    // Ensure the widget is still mounted before proceeding
+    if (!mounted) return;
+
     // Calculate scrolling length.
     double scrollLength =
         _textWidth + widget.spaceSize + widget.startPaddingSize;
@@ -90,6 +93,9 @@ class _TextMarqueeState extends State<TextMarquee> {
             ? widget.duration!
             : Duration(milliseconds: (scrollLength * 27).toInt()),
         curve: widget.curve);
+
+    // Ensure the widget is still mounted before jumping
+    if (!mounted) return;
 
     // Jump to start of SingleChildScrollView. (without animation)
     _scrollController.jumpTo(0);


### PR DESCRIPTION
Hi!

I encountered an issue when navigating away from the screen containing the `TextMarquee` widget. The app would throw an error due to the `ScrollController` being used after the widget was removed from the widget tree. 

To fix this, I added checks to ensure the widget is still mounted before attempting to perform any scrolling actions in the `_startAnimating` method. This prevents unhandled exceptions and improves the widget's stability.

Let me know if you have any questions or feedback!
